### PR TITLE
Export `default` in each module

### DIFF
--- a/src/go/index.ts
+++ b/src/go/index.ts
@@ -26,3 +26,5 @@ export * from "./main_visitor.js";
 export * from "./scaffold_visitor.js";
 export * from "./struct_visitor.js";
 export * from "./union_visitor.js";
+
+export { InterfacesVisitor as default } from "./interfaces_visitor.js";

--- a/src/json-schema/index.ts
+++ b/src/json-schema/index.ts
@@ -1,1 +1,3 @@
 export { JsonSchemaVisitor } from "./json-schema.js";
+
+export { JsonSchemaVisitor as default } from "./json-schema.js";

--- a/src/openapiv3/index.ts
+++ b/src/openapiv3/index.ts
@@ -15,3 +15,5 @@ limitations under the License.
 */
 
 export * from "./openapiv3.js";
+
+export { OpenAPIV3Visitor as default } from "./openapiv3.js";

--- a/src/proto/index.ts
+++ b/src/proto/index.ts
@@ -15,3 +15,6 @@ limitations under the License.
 */
 
 export * from "./proto_visitor.js";
+
+export { ProtoVisitor as default } from "./proto_visitor.js";
+

--- a/src/python/index.ts
+++ b/src/python/index.ts
@@ -19,3 +19,5 @@ export * from "./interfaces_visitor.js";
 export * from "./scaffold_visitor.js";
 export * from "./helpers.js";
 export * from "./constant.js";
+
+export { InterfacesVisitor as default } from "./interfaces_visitor.js";

--- a/src/rust/index.ts
+++ b/src/rust/index.ts
@@ -1,1 +1,3 @@
 export { RustBasic } from "./rust-basic.js";
+
+export { RustBasic as default } from "./rust-basic.js";

--- a/src/typescript/index.ts
+++ b/src/typescript/index.ts
@@ -19,3 +19,5 @@ export * from "./interfaces_visitor.js";
 export * from "./scaffold_visitor.js";
 export * from "./helpers.js";
 export * from "./constant.js";
+
+export { InterfacesVisitor as default } from "./interfaces_visitor.js";


### PR DESCRIPTION
This PR adds an export for `DefaultVisitor` to each module. It is assumed that no configuration is necessary for the visitor to emit valid code.