### PR TITLE
Rust: Fixed case for aliased primitives, trimmed whitespace

### DIFF
--- a/src/rust/rust-basic.ts
+++ b/src/rust/rust-basic.ts
@@ -39,8 +39,9 @@ export class RustBasic extends ContextWriter {
   visitAlias(context: Context): void {
     const { alias } = context;
     this.append(
-      `pub type ${rustifyCaps(alias.name)} = ${rustifyCaps(
-        types.apexToRustType(alias.type, context.config)
+      `pub type ${rustifyCaps(alias.name)} = ${types.apexToRustType(
+        alias.type,
+        context.config
       )};\n`
     );
   }

--- a/src/rust/visitors/enum_visitor.ts
+++ b/src/rust/visitors/enum_visitor.ts
@@ -42,9 +42,11 @@ export class EnumVisitor extends SourceGenerator<Enum> {
     this.hasDisplayValues ||= enumValue.display !== undefined;
     this.hasIndices ||= enumValue.index !== undefined;
 
-    this.append(`
+    this.append(
+      `
       ${trimLines([rustDoc(enumValue.description)])}
-      ${rustifyCaps(enumValue.name)},`);
+      ${rustifyCaps(enumValue.name)},`.trim()
+    );
   }
 }
 
@@ -71,14 +73,16 @@ function displayImpl(node: Enum): string {
 }
 
 function fromIndexImpl(node: Enum): string {
+  let type = "u32";
+
   let patterns = node.values
     .filter((v) => v.index !== undefined)
     .map((v) => `${v.index} => Ok(Self::${rustifyCaps(v.name)})`)
     .join(",");
   return `
-  impl std::convert::TryFrom<u32> for ${rustifyCaps(node.name)} {
+  impl std::convert::TryFrom<${type}> for ${rustifyCaps(node.name)} {
     type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
-    fn try_from(index: u32) -> Result<Self, Self::Error> {
+    fn try_from(index: ${type}) -> Result<Self, Self::Error> {
       match index {
         ${patterns},
         _ => Err(format!("{} is not a valid index for ${rustifyCaps(

--- a/src/rust/visitors/struct_visitor.ts
+++ b/src/rust/visitors/struct_visitor.ts
@@ -55,7 +55,7 @@ export class StructVisitor extends SourceGenerator<Type> {
     this.append(
       `${trimLines([rustDoc(field.description), serdeAnnotation])}
       ${this.visibility} ${rustify(field.name)}: ${typeString},
-      `
+      `.trim()
     );
   }
 }


### PR DESCRIPTION
This PR cleans up some errant whitespace and fixed a case where aliases to primitive types were being improperly uppercased.