### PR TITLE
Added ability to generate rust references with lifetimes

### DIFF
--- a/src/rust/utils/types.ts
+++ b/src/rust/utils/types.ts
@@ -15,12 +15,18 @@ import {
 } from "@apexlang/core/model";
 import { rustifyCaps } from "./index.js";
 
-export function apexToRustType(typ: AnyType, config: ObjectMap<any>): string {
+export function apexToRustType(
+  typ: AnyType,
+  config: ObjectMap<any>,
+  asRef = false,
+  lifetime = ""
+): string {
+  const ref = asRef ? `&${lifetime} ` : "";
   switch (typ.kind) {
     case Kind.List: {
       const t = typ as List;
       const itemType = apexToRustType(t.type, config);
-      return `Vec<${itemType}>`;
+      return asRef ? `${ref}[${itemType}]` : `Vec<${itemType}>`;
     }
     case Kind.Map: {
       const t = typ as Map;
@@ -28,25 +34,25 @@ export function apexToRustType(typ: AnyType, config: ObjectMap<any>): string {
       const keyType = apexToRustType(t.keyType, config);
       const valueType = apexToRustType(t.valueType, config);
 
-      return `std::collections::HashMap<${keyType},${valueType}>`;
+      return `${ref}std::collections::HashMap<${keyType},${valueType}>`;
     }
     case Kind.Optional: {
       const t = typ as Optional;
       const innerType = apexToRustType(t.type, config);
-      return `Option<${innerType}>`;
+      return `${ref}Option<${innerType}>`;
     }
     case Kind.Union:
     case Kind.Enum:
     case Kind.Alias:
     case Kind.Type: {
-      return rustifyCaps((typ as Named).name);
+      return `${ref}${rustifyCaps((typ as Named).name)}`;
     }
     case Kind.Void: {
       return "()";
     }
     case Kind.Primitive: {
       const t = typ as Primitive;
-      return primitiveToRust(t, config);
+      return primitiveToRust(t, config, asRef, lifetime);
     }
     default: {
       throw new Error(`Unhandled type conversion for type: ${typ.kind}`);
@@ -54,38 +60,52 @@ export function apexToRustType(typ: AnyType, config: ObjectMap<any>): string {
   }
 }
 
-function primitiveToRust(t: Primitive, config: ObjectMap<any>): string {
+function primitiveToRust(
+  t: Primitive,
+  config: ObjectMap<any>,
+  asRef = false,
+  lifetime = ""
+): string {
+  const ref = asRef ? `&${lifetime} ` : "";
   switch (t.name) {
     case PrimitiveName.Bool:
-      return "bool";
-    case PrimitiveName.Bytes:
-      return config.bytes ? config.bytes : "Vec<u8>";
-    case PrimitiveName.DateTime:
-      return "time::OffsetDateTime";
+      return `${ref}bool`;
+    case PrimitiveName.Bytes: {
+      const typ = config.bytes ? config.bytes : "Vec<u8>";
+      return `${ref}${typ}`;
+    }
+    case PrimitiveName.DateTime: {
+      const typ = config.datetime ? config.datetime : "time::OffsetDateTime";
+      return `${ref}${typ}`;
+    }
     case PrimitiveName.F32:
-      return "f32";
+      return `${ref}f32`;
     case PrimitiveName.F64:
-      return "f64";
+      return `${ref}f64`;
     case PrimitiveName.U64:
-      return "u64";
+      return `${ref}u64`;
     case PrimitiveName.U32:
-      return "u32";
+      return `${ref}u32`;
     case PrimitiveName.U16:
-      return "u16";
+      return `${ref}u16`;
     case PrimitiveName.U8:
-      return "u8";
+      return `${ref}u8`;
     case PrimitiveName.I64:
-      return "i64";
+      return `${ref}i64`;
     case PrimitiveName.I32:
-      return "i32";
+      return `${ref}i32`;
     case PrimitiveName.I16:
-      return "i16";
+      return `${ref}i16`;
     case PrimitiveName.I8:
-      return "i8";
+      return `${ref}i8`;
     case PrimitiveName.String:
-      return "String";
-    case PrimitiveName.Any:
-      return config.anyType ? config.anyType.toString() : "serde_value::Value";
+      return asRef ? `${ref}str` : "String";
+    case PrimitiveName.Any: {
+      const typ = config.anyType
+        ? config.anyType.toString()
+        : "serde_value::Value";
+      return `${ref}${typ}`;
+    }
     default:
       throw new Error(
         `Unhandled primitive type conversion for type: ${t.name}`

--- a/src/rust/visitors/struct_visitor.ts
+++ b/src/rust/visitors/struct_visitor.ts
@@ -50,7 +50,11 @@ export class StructVisitor extends SourceGenerator<Type> {
     let serdeAnnotation = "";
     if (useSerde(context.config)) {
       let date_with = "";
-      if (isPrimitive(field.type) && field.type.name === "datetime") {
+      if (
+        isPrimitive(field.type) &&
+        field.type.name === "datetime" &&
+        !this.config.datetime
+      ) {
         date_with = ',with = "time::serde::rfc3339"';
       }
       serdeAnnotation = `#[serde(rename = "${field.name}"${date_with})]`;


### PR DESCRIPTION
This PR adds a flag to the type conversion function and gives it support for generating type references with optional lifetimes.