### PR TITLE
chore: apexlang/core version bump and expandType for Go includes interface

### DIFF
--- a/src/deps/core/ast.ts
+++ b/src/deps/core/ast.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/x/apex_core@v0.1.2/ast/mod.ts";
+export * from "https://deno.land/x/apex_core@v0.1.3/ast/mod.ts";

--- a/src/deps/core/model.ts
+++ b/src/deps/core/model.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/x/apex_core@v0.1.2/model/mod.ts";
+export * from "https://deno.land/x/apex_core@v0.1.3/model/mod.ts";

--- a/src/go/helpers.ts
+++ b/src/go/helpers.ts
@@ -234,7 +234,8 @@ export const expandType = (
     case Kind.Alias:
     case Kind.Enum:
     case Kind.Type:
-    case Kind.Union: {
+    case Kind.Union:
+    case Kind.Interface: {
       let namedValue = (type as Named).name;
       if (translate != undefined) {
         namedValue = translate(namedValue) || namedValue;


### PR DESCRIPTION
* version bump to `@apexlang/core` v0.1.3
* Go: adding `Interface` to `expandType`